### PR TITLE
Add header check to middleware

### DIFF
--- a/Classes/Middleware/GetAuthenticationCode.php
+++ b/Classes/Middleware/GetAuthenticationCode.php
@@ -68,10 +68,12 @@ class GetAuthenticationCode implements MiddlewareInterface
      */
     protected function isInstagramAuthentificationRedirect(ServerRequestInterface $request): bool
     {
-        if (!empty($request->getQueryParams()['code'])) {
-            $code = $request->getQueryParams()['code'];
-            if (strlen($code) > 8) {
-                return true;
+        if (in_array('https://l.instagram.com/', $request->getHeader('referer'))) {
+            if (!empty($request->getQueryParams()['code'])) {
+                $code = $request->getQueryParams()['code'];
+                if (strlen($code) > 8) {
+                    return true;
+                }
             }
         }
         return false;


### PR DESCRIPTION
With the current way the request is being checked, this middleware will clash with any service using a parameter named "code" as a part of their OAuth flow. Checking if the `referer` is `https://l.instagram.com/` will avoid this problem. 