### PR TITLE
Add possibility to set a range for the feed

### DIFF
--- a/Configuration/FlexForms/FlexFormPi1.xml
+++ b/Configuration/FlexForms/FlexFormPi1.xml
@@ -54,6 +54,25 @@
 							</config>
 						</TCEforms>
 					</settings.appReturnUrl>
+					<settings.firstPost>
+						<TCEforms>
+							<exclude>1</exclude>
+							<label>Start at post</label>
+							<config>
+								<type>input</type>
+								<default>1</default>
+								<eval>trim,int</eval>
+								<range>
+									<lower>1</lower>
+									<upper>100</upper>
+								</range>
+								<slider>
+									<step>1</step>
+									<width>400</width>
+								</slider>
+							</config>
+						</TCEforms>
+					</settings.firstPost>
 					<settings.limit>
 						<TCEforms>
 							<exclude>1</exclude>

--- a/Resources/Private/Templates/PreviewRenderer/InstagramPi1.html
+++ b/Resources/Private/Templates/PreviewRenderer/InstagramPi1.html
@@ -11,9 +11,10 @@
 				<f:alias map="{images:'{instagram:backend.getFeed(flexForm:flexForm)}'}">
 					<f:if condition="{images.data -> f:count()} > 0">
 						<f:then>
+							<f:variable name="lastPost">{flexForm.settings.firstPost + flexForm.settings.limit - 1}</f:variable>
 							<f:for each="{images.data}" as="image" iteration="iteration">
-								<f:if condition="{iteration.cycle} < 7">
-									<div class="col-md-2">
+								<f:if condition="{iteration.cycle} >= {flexForm.settings.firstPost} && {iteration.cycle} <= {lastPost} && {iteration.cycle} <= 8">
+									<div class="col-md-4">
 										<instagram:isLocalImageExisting id="{image.id}">
 											<f:then>
 												<f:image src="/typo3temp/assets/tx_instagram/{image.id}.jpg" alt="{image.caption}" width="500c" height="500c" />

--- a/Resources/Private/Templates/Profile/Show.html
+++ b/Resources/Private/Templates/Profile/Show.html
@@ -2,10 +2,13 @@
 	  xmlns:instagram="http://typo3.org/ns/In2code/Instagram/ViewHelpers"
 	  data-namespace-typo3-fluid="true">
 
+
+<f:variable name="lastPost">{settings.firstPost + settings.limit - 1}</f:variable>
+
 <div class="c-socialwall">
 	<div class="c-socialwall">
 		<f:for each="{feed.data}" as="image" iteration="iteration">
-			<f:if condition="{iteration.cycle} <= {settings.limit}">
+			<f:if condition="{iteration.cycle} >= {settings.firstPost} && {iteration.cycle} <= {lastPost} ">
 				<div class="c-socialwall__item c-socialwall__item--instagram">
 					<f:link.external uri="{image.permalink}" title="Instagram profile {settings.username}" target="_blank" rel="noopener">
 


### PR DESCRIPTION
If you have various tiles on your site, maybe some news tiles and then some excerpts from your insta feed, you will welcome the possibility to specify a range in your plugin. 

I have added that to the flexform, to the show template as well as to the backend preview (which in this commit only shows the chosen number of posts (max 8) and a tad larger)

![Screenshot-30 07-001596](https://user-images.githubusercontent.com/1446443/181918532-76d6c453-c79c-4280-9eac-954db45babe2.jpg)

![Screenshot-30 07-001593](https://user-images.githubusercontent.com/1446443/181918474-77154c9e-f904-41f3-8c18-c29963b403b6.jpg)

![Screenshot-30 07-001595](https://user-images.githubusercontent.com/1446443/181918516-7ed93d62-cc46-4019-875c-5549ee348653.jpg)
