### PR TITLE
Add firstPost setting to allow selection by range

### DIFF
--- a/Configuration/FlexForms/FlexFormPi1.xml
+++ b/Configuration/FlexForms/FlexFormPi1.xml
@@ -54,6 +54,25 @@
 							</config>
 						</TCEforms>
 					</settings.appReturnUrl>
+					<settings.firstPost>
+						<TCEforms>
+							<exclude>1</exclude>
+							<label>Start at post</label>
+							<config>
+								<type>input</type>
+								<default>1</default>
+								<eval>trim,int</eval>
+								<range>
+									<lower>1</lower>
+									<upper>100</upper>
+								</range>
+								<slider>
+									<step>1</step>
+									<width>400</width>
+								</slider>
+							</config>
+						</TCEforms>
+					</settings.firstPost>
 					<settings.limit>
 						<TCEforms>
 							<exclude>1</exclude>

--- a/Resources/Private/Templates/PreviewRenderer/InstagramPi1.html
+++ b/Resources/Private/Templates/PreviewRenderer/InstagramPi1.html
@@ -11,7 +11,14 @@
 				<f:alias map="{images:'{instagram:backend.getFeed(flexForm:flexForm)}'}">
 					<f:if condition="{images.data -> f:count()} > 0">
 						<f:then>
-							<f:variable name="lastPost">{flexForm.settings.firstPost + flexForm.settings.limit - 1}</f:variable>
+							<f:if condition="{settings.firstPost}">
+								<f:then>
+									<f:variable name="lastPost">{settings.firstPost + settings.limit - 1}</f:variable>
+								</f:then>
+								<f:else>
+									<f:variable name="lastPost">999999</f:variable>
+								</f:else>
+							</f:if>
 							<f:for each="{images.data}" as="image" iteration="iteration">
 								<f:if condition="{iteration.cycle} >= {flexForm.settings.firstPost} && {iteration.cycle} <= {lastPost} && {iteration.cycle} <= 8">
 									<div class="col-md-4">

--- a/Resources/Private/Templates/PreviewRenderer/InstagramPi1.html
+++ b/Resources/Private/Templates/PreviewRenderer/InstagramPi1.html
@@ -11,9 +11,10 @@
 				<f:alias map="{images:'{instagram:backend.getFeed(flexForm:flexForm)}'}">
 					<f:if condition="{images.data -> f:count()} > 0">
 						<f:then>
+							<f:variable name="lastPost">{flexForm.settings.firstPost + flexForm.settings.limit - 1}</f:variable>
 							<f:for each="{images.data}" as="image" iteration="iteration">
-								<f:if condition="{iteration.cycle} < 7">
-									<div class="col-md-2">
+								<f:if condition="{iteration.cycle} >= {flexForm.settings.firstPost} && {iteration.cycle} <= {lastPost} && {iteration.cycle} <= 8">
+									<div class="col-md-4">
 										<instagram:isLocalImageExisting id="{image.id}">
 											<f:then>
 												<f:image src="/typo3temp/assets/tx_instagram/{image.id}.jpg" alt="{image.caption}" width="500c" height="500c" />

--- a/Resources/Private/Templates/Profile/Show.html
+++ b/Resources/Private/Templates/Profile/Show.html
@@ -2,10 +2,13 @@
 	  xmlns:instagram="http://typo3.org/ns/In2code/Instagram/ViewHelpers"
 	  data-namespace-typo3-fluid="true">
 
+
+<f:variable name="lastPost">{settings.firstPost + settings.limit - 1}</f:variable>
+
 <div class="c-socialwall">
 	<div class="c-socialwall">
 		<f:for each="{feed.data}" as="image" iteration="iteration">
-			<f:if condition="{iteration.cycle} <= {settings.limit}">
+			<f:if condition="{iteration.cycle} >= {settings.firstPost} && {iteration.cycle} <= {lastPost} ">
 				<div class="c-socialwall__item c-socialwall__item--instagram">
 					<f:link.external uri="{image.permalink}" title="Instagram profile {settings.username}" target="_blank" rel="noopener">
 

--- a/Resources/Private/Templates/Profile/Show.html
+++ b/Resources/Private/Templates/Profile/Show.html
@@ -2,8 +2,14 @@
 	  xmlns:instagram="http://typo3.org/ns/In2code/Instagram/ViewHelpers"
 	  data-namespace-typo3-fluid="true">
 
-
-<f:variable name="lastPost">{settings.firstPost + settings.limit - 1}</f:variable>
+<f:if condition="{settings.firstPost}">
+	<f:then>
+		<f:variable name="lastPost">{settings.firstPost + settings.limit - 1}</f:variable>
+	</f:then>
+	<f:else>
+		<f:variable name="lastPost">999999</f:variable>
+	</f:else>
+</f:if>
 
 <div class="c-socialwall">
 	<div class="c-socialwall">


### PR DESCRIPTION
If you have various teasers on your site, maybe some news teasers and then some excerpts from your instagram feed, you will welcome the possibility to specify a **range** in your plugin (in my case: show the first post in one plugin, show the second post in another plugin).

I have added that to the flexform, to the show template as well as to the backend preview (which in this commit only shows the chosen number of posts (max 8) and a tad larger)

Screenshots see https://github.com/in2code-de/instagram/pull/19